### PR TITLE
47 download report pdf file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Status message display in overlay. [#26](https://github.com/clowder-framework/CONSORT-frontend/issues/26)
 - PreviewDrawer component displays number of items missed per section. [#43](https://github.com/clowder-framework/CONSORT-frontend/issues/43)
+- Pdf report file is downloaded after preview generated. [#47](https://github.com/clowder-framework/CONSORT-frontend/issues/47)
 
 ### Fixed
 - Display of error messages on uploading files in dropzone. [#26](https://github.com/clowder-framework/CONSORT-frontend/issues/26)

--- a/src/components/childComponents/PreviewDrawerLeft.js
+++ b/src/components/childComponents/PreviewDrawerLeft.js
@@ -27,6 +27,7 @@ export default function PreviewDrawerLeft(props) {
 	const [itemsMissed, setItemsMissed] = useState('');
 	const [checklist, setChecklist] = useState([]);
 	const [openSections, setOpenSections] = useState([]);
+	const [reportFileID, setReportFileID] = useState('');
 
 	useEffect(() => {
 		if (metadata !== undefined && metadata.content !== undefined){
@@ -35,6 +36,7 @@ export default function PreviewDrawerLeft(props) {
 			setExtractor(content["extractor"]);
 			setItemsMissed(content["items_missed"]);
 			setChecklist(content["checklist"]);
+			setReportFileID(content["extracted_files"][1]["file_id"])
 		}
 	},[]);
 
@@ -58,7 +60,7 @@ export default function PreviewDrawerLeft(props) {
 
 
 	const onDownload = () => {
-		downloadFile(fileId, "results.html").then(r => console.log(r));
+		downloadFile(reportFileID, "results.pdf").then(r => console.log(r));
 	}
 
 	return (


### PR DESCRIPTION
The generated pdf report file is being downloaded instead of html file.
The dataset metadata has all extracted file IDs (https://github.com/clowder-framework/RCT-Transparency-extractor/pull/29)
The report pdf file ID is read from this metadata.