### PR TITLE
64 pdf file preview pdfjs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PreviewDrawer component displays number of items missed per section. [#43](https://github.com/clowder-framework/CONSORT-frontend/issues/43)
 - Pdf report file is downloaded after preview generated. [#47](https://github.com/clowder-framework/CONSORT-frontend/issues/47)
 - CILogon with specific IDP entities. [#50](https://github.com/clowder-framework/CONSORT-frontend/issues/50)
+- Pdf file previewer using PDFjs library. [#64](https://github.com/clowder-framework/CONSORT-frontend/issues/64)
 
 ### Fixed
 - Display of error messages on uploading files in dropzone. [#26](https://github.com/clowder-framework/CONSORT-frontend/issues/26)

--- a/package-lock.json
+++ b/package-lock.json
@@ -12573,9 +12573,9 @@
       }
     },
     "pdfjs-dist": {
-      "version": "3.11.174",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-3.11.174.tgz",
-      "integrity": "sha512-TdTZPf1trZ8/UFu5Cx/GXB7GZM30LT+wWUNfsi6Bq8ePLnb+woNKtDymI2mxZYBpMbonNFqKmiz684DIfnd8dA==",
+      "version": "4.0.189",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-4.0.189.tgz",
+      "integrity": "sha512-5IWbLRJjQJhk3cu3nNFAvIYoSzT8xRYlRkFCIV1tn7hK1eq9H+6vOP0ytJhZz9YI35IXlu33uQspvmYO6Oir4g==",
       "requires": {
         "canvas": "^2.11.2",
         "path2d-polyfill": "^2.0.1"
@@ -13835,6 +13835,15 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
           "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q=="
+        },
+        "pdfjs-dist": {
+          "version": "3.11.174",
+          "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-3.11.174.tgz",
+          "integrity": "sha512-TdTZPf1trZ8/UFu5Cx/GXB7GZM30LT+wWUNfsi6Bq8ePLnb+woNKtDymI2mxZYBpMbonNFqKmiz684DIfnd8dA==",
+          "requires": {
+            "canvas": "^2.11.2",
+            "path2d-polyfill": "^2.0.1"
+          }
         }
       }
     },
@@ -14738,9 +14747,9 @@
       }
     },
     "semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true
     },
     "semver-compare": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
 		"date-fns": "^2.28.0",
 		"express": "^4.18.2",
 		"jquery": "^3.6.0",
+		"pdfjs-dist": "^4.0.189",
 		"prop-types": "^15.7.2",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",

--- a/src/components/previewers/Pdf.js
+++ b/src/components/previewers/Pdf.js
@@ -1,41 +1,90 @@
 // Preview Pdf file
-import React, { useState } from "react";
-//import pdfjsLib;
-import { pdfjs } from 'react-pdf';
-import { Document, Page } from 'react-pdf';
+import React, { useEffect, useState, useRef, useCallback } from "react";
+import * as pdfjsLib from "pdfjs-dist/build/pdf";
+import pdfjsWorker from "pdfjs-dist/build/pdf.worker.entry";
+//import { pdfjs } from 'react-pdf';
+//import { Document, Page } from 'react-pdf';
 
-pdfjs.GlobalWorkerOptions.workerSrc = new URL(
-	'pdfjs-dist/build/pdf.worker.min.js',
-	import.meta.url,
-).toString();
+// pdfjs.GlobalWorkerOptions.workerSrc = new URL(
+// 	'pdfjs-dist/build/pdf.worker.min.js',
+// 	import.meta.url,
+// ).toString();
 
 export default function Pdf(props) {
 	const {fileId, pdfSrc, ...other} = props;
 	// var loadingTask = pdfjsLib.getDocument(pdfSrc);
 	// loadingTask.promise.then(function(pdf) {
-	// 	// you can now use *pdf* here
+	// 	pdf.getPage(1).then(function(page) {
+	// 		// you can now use *page* here
+	// 		var scale = 1.5;
+	// 		var viewport = page.getViewport({ scale: scale, });
+	// 		var outputScale = window.devicePixelRatio || 1;
+	//
+	// 		var canvas = document.getElementById('the-canvas');
+	// 		var context = canvas.getContext('2d');
+	//
+	// 		canvas.width = Math.floor(viewport.width * outputScale);
+	// 		canvas.height = Math.floor(viewport.height * outputScale);
+	// 		canvas.style.width = Math.floor(viewport.width) + "px";
+	// 		canvas.style.height =  Math.floor(viewport.height) + "px";
+	//
+	// 		var transform = outputScale !== 1
+	// 			? [outputScale, 0, 0, outputScale, 0, 0]
+	// 			: null;
+	//
+	// 		var renderContext = {
+	// 			canvasContext: context,
+	// 			transform: transform,
+	// 			viewport: viewport
+	// 		};
+	// 		page.render(renderContext);
+	// 	});
 	// });
+
+	const canvasRef = useRef();
+	pdfjsLib.GlobalWorkerOptions.workerSrc = pdfjsWorker;
+
+	const [pdfRef, setPdfRef] = useState();
+	const [currentPage, setCurrentPage] = useState(1);
+
 	const [numPages, setNumPages] = useState(null);
 	const [pageNumber, setPageNumber] = useState(1);
 
-	function onDocumentLoadSuccess({ numPages }) {
-		setNumPages(numPages);
-		setPageNumber(1);
-	}
-	function changePage(offset) {
-		setPageNumber(prevPageNumber => prevPageNumber + offset);
-	}
+	const renderPage = useCallback((pageNum, pdf=pdfRef) => {
+		pdf && pdf.getPage(pageNum).then(function(page) {
+			const viewport = page.getViewport({scale: 1.5});
+			const canvas = canvasRef.current;
+			canvas.height = viewport.height;
+			canvas.width = viewport.width;
+			const renderContext = {
+				canvasContext: canvas.getContext('2d'),
+				viewport: viewport
+			};
+			page.render(renderContext);
+		});
+	}, [pdfRef]);
 
-	function previousPage() {
-		changePage(-1);
-	}
+	useEffect(() => {
+		renderPage(currentPage, pdfRef);
+	}, [pdfRef, currentPage, renderPage]);
 
-	function nextPage() {
-		changePage(1);
-	}
+	useEffect(() => {
+		const loadingTask = pdfjsLib.getDocument(pdfSrc);
+		loadingTask.promise.then(loadedPdf => {
+			setPdfRef(loadedPdf);
+		}, function (reason) {
+			console.error(reason);
+		});
+	}, [pdfSrc]);
 
-	return (
-		<iframe id={fileId} src={pdfSrc} style={{"width":"100%", "height":"1000px"}} />
+	const nextPage = () => pdfRef && currentPage < pdfRef.numPages && setCurrentPage(currentPage + 1);
+
+	const prevPage = () => currentPage > 1 && setCurrentPage(currentPage - 1);
+
+	return <canvas ref={canvasRef}></canvas>;
+
+		//<iframe id={fileId} src={pdfSrc} style={{"width":"100%", "height":"1000px"}} />
+
 		// <div>
 		// 	<Document file={pdfSrc} onLoadSuccess={onDocumentLoadSuccess}>
 		// 		<Page pageNumber={pageNumber} />
@@ -58,5 +107,4 @@ export default function Pdf(props) {
 		// 		Next
 		// 	</button>
 		// </div>
-	);
 }

--- a/src/components/previewers/Pdf.js
+++ b/src/components/previewers/Pdf.js
@@ -1,54 +1,17 @@
 // Preview Pdf file
 import React, { useEffect, useState, useRef, useCallback } from "react";
-import * as pdfjsLib from "pdfjs-dist/build/pdf";
-import pdfjsWorker from "pdfjs-dist/build/pdf.worker.entry";
-//import { pdfjs } from 'react-pdf';
-//import { Document, Page } from 'react-pdf';
+import * as pdfjsLib from "pdfjs-dist";
+import pdfjsWorker from "pdfjs-dist/build/pdf.worker.min.mjs";
 
-// pdfjs.GlobalWorkerOptions.workerSrc = new URL(
-// 	'pdfjs-dist/build/pdf.worker.min.js',
-// 	import.meta.url,
-// ).toString();
 
 export default function Pdf(props) {
 	const {fileId, pdfSrc, ...other} = props;
-	// var loadingTask = pdfjsLib.getDocument(pdfSrc);
-	// loadingTask.promise.then(function(pdf) {
-	// 	pdf.getPage(1).then(function(page) {
-	// 		// you can now use *page* here
-	// 		var scale = 1.5;
-	// 		var viewport = page.getViewport({ scale: scale, });
-	// 		var outputScale = window.devicePixelRatio || 1;
-	//
-	// 		var canvas = document.getElementById('the-canvas');
-	// 		var context = canvas.getContext('2d');
-	//
-	// 		canvas.width = Math.floor(viewport.width * outputScale);
-	// 		canvas.height = Math.floor(viewport.height * outputScale);
-	// 		canvas.style.width = Math.floor(viewport.width) + "px";
-	// 		canvas.style.height =  Math.floor(viewport.height) + "px";
-	//
-	// 		var transform = outputScale !== 1
-	// 			? [outputScale, 0, 0, outputScale, 0, 0]
-	// 			: null;
-	//
-	// 		var renderContext = {
-	// 			canvasContext: context,
-	// 			transform: transform,
-	// 			viewport: viewport
-	// 		};
-	// 		page.render(renderContext);
-	// 	});
-	// });
 
 	const canvasRef = useRef();
 	pdfjsLib.GlobalWorkerOptions.workerSrc = pdfjsWorker;
 
 	const [pdfRef, setPdfRef] = useState();
 	const [currentPage, setCurrentPage] = useState(1);
-
-	const [numPages, setNumPages] = useState(null);
-	const [pageNumber, setPageNumber] = useState(1);
 
 	const renderPage = useCallback((pageNum, pdf=pdfRef) => {
 		pdf && pdf.getPage(pageNum).then(function(page) {
@@ -81,30 +44,27 @@ export default function Pdf(props) {
 
 	const prevPage = () => currentPage > 1 && setCurrentPage(currentPage - 1);
 
-	return <canvas ref={canvasRef}></canvas>;
+	return (
+		<>
+			<div id="canvas-preview">
+				<canvas ref={canvasRef}></canvas>
+			</div>
+			<div id="pagination">
+				<button
+						type="button"
+						onClick={prevPage}
+					>
+						Previous
+					</button>
+					<button
+						type="button"
+						onClick={nextPage}
+					>
+						Next
+					</button>
 
-		//<iframe id={fileId} src={pdfSrc} style={{"width":"100%", "height":"1000px"}} />
+			</div>
+		</>
+	);
 
-		// <div>
-		// 	<Document file={pdfSrc} onLoadSuccess={onDocumentLoadSuccess}>
-		// 		<Page pageNumber={pageNumber} />
-		// 	</Document>
-		// 	<p>
-		// 		Page {pageNumber || (numPages ? 1 : '--')} of {numPages || '--'}
-		// 	</p>
-		// 	<button
-		// 		type="button"
-		// 		disabled={pageNumber <= 1}
-		// 		onClick={previousPage}
-		// 	>
-		// 		Previous
-		// 	</button>
-		// 	<button
-		// 		type="button"
-		// 		disabled={pageNumber >= numPages}
-		// 		onClick={nextPage}
-		// 	>
-		// 		Next
-		// 	</button>
-		// </div>
 }

--- a/src/components/previewers/Pdf.js
+++ b/src/components/previewers/Pdf.js
@@ -1,7 +1,7 @@
 // Preview Pdf file
 import React, { useEffect, useState, useRef, useCallback } from "react";
 import * as pdfjsLib from "pdfjs-dist";
-import pdfjsWorker from "pdfjs-dist/build/pdf.worker.min.mjs";
+import pdfjsWorker from "pdfjs-dist/build/pdf.worker.min.js";
 
 
 export default function Pdf(props) {


### PR DESCRIPTION
PDFjs library is used to render Pdf file in previewers. It is rendered using canvas.
The PdfJS lib renderes each page one by one. A page navigation is implemented (buttons below the canvas).
Majority of the code is taken from https://stackoverflow.com/questions/55371402/how-to-reference-pdf-js-library-in-react 

**Fixes : #64** 


![Screenshot 2023-11-12 at 4 41 56 PM](https://github.com/clowder-framework/CONSORT-frontend/assets/22112888/0bd7eb6a-9e5b-4998-9040-a9c13fb25765)
