### PR TITLE
70 highlight sentences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ yarn-error.log*
 #package file
 /server/var/db/
 /dist
+
+# data folder
+/data
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CLOWDER_PREFIX environment variable for prefix url. [#65](https://github.com/clowder-framework/CONSORT-frontend/issues/65)
 - Pdf file previewer.  [#61](https://github.com/clowder-framework/CONSORT-frontend/issues/61)
 - Highlighting sentences using canvas and coordinates from metadata. [#61](https://github.com/clowder-framework/CONSORT-frontend/issues/61)
+- Highlight sentences with label at the side. [#70](https://github.com/clowder-framework/CONSORT-frontend/issues/70) , [#75](https://github.com/clowder-framework/CONSORT-frontend/issues/75)
 
 ### Changed
 - Status message display in overlay. [#26](https://github.com/clowder-framework/CONSORT-frontend/issues/26)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "consort-frontend",
-	"version": "0.3.0",
+	"version": "0.4.0",
 	"description": "",
 	"engines": {
 		"npm": ">=8.11",

--- a/src/actions/client.js
+++ b/src/actions/client.js
@@ -59,10 +59,10 @@ export function createUploadExtract(file) {
 						const pdf_metadata = await getPdfMetadataLoop(dataset_json.id, clientInfo);
 						if (pdf_metadata !== null){
 							console.log("pdf extraction done");
-							const text_file_name = file_name + '.txt';
-							const extracted_txt_file = await getFileInDataset(dataset_json.id, "text/file", text_file_name, clientInfo);
-							if (extracted_txt_file !== null && typeof extracted_txt_file.id === "string") {
-								const rct_extraction_submission = await submitForExtraction(extracted_txt_file.id, config.rct_extractor, clientInfo);
+							const csv_file_name = file_name + '.csv';
+							const extracted_csv_file = await getFileInDataset(dataset_json.id, "text/csv", csv_file_name, clientInfo);
+							if (extracted_csv_file !== null && typeof extracted_csv_file.id === "string") {
+								const rct_extraction_submission = await submitForExtraction(extracted_csv_file.id, config.rct_extractor, clientInfo);
 								if (rct_extraction_submission === true){
 									// check every 5s for extraction status
 									//const rct_extraction_status = await checkExtractionStatusLoop(extracted_txt_file.id, config.rct_extractor, 5000, clientInfo);

--- a/src/components/childComponents/CreateAndUpload.js
+++ b/src/components/childComponents/CreateAndUpload.js
@@ -54,11 +54,12 @@ export default function CreateAndUpload() {
 			// check extraction status and html file generation in loop
 			const html_file_loop = async () => {
 				setLoadingText("Checking extraction status");
-				const html_output_filename = file_name + '_predicted' + '.html'
-				const htmlFile = await getFileInDataset(dataset_id, "text/html", html_output_filename, clientInfo);
-				if (htmlFile !== null && typeof htmlFile.id === "string") {
+				const highlights_filename = file_name + '_highlights' + '.json'
+				const highlightsFile = await getFileInDataset(dataset_id, "application/json", highlights_filename, clientInfo);
+				if (highlightsFile !== null && typeof highlightsFile.id === "string") {
 					// {"id":string, "size":string, "date-created":string, "contentType":text/html, "filename":string}
 					const metadata = await getDatasetMetadata(dataset_id, clientInfo);
+					console.log("metadata", metadata);
 					// get the metadata content list
 					const contentList = metadata.map(item => item.content[0]);
 					const pdfExtractorContent = contentList.find(item => item.extractor === pdfExtractor);
@@ -70,7 +71,7 @@ export default function CreateAndUpload() {
 						listFilePreviews(pdf_input_file, clientInfo);
 					}
 					else{
-						listFilePreviews(htmlFile.id, clientInfo);
+						listFilePreviews(highlightsFile.id, clientInfo);
 					}
 					datasetMetadata(metadata);
 
@@ -78,7 +79,7 @@ export default function CreateAndUpload() {
 					setPreview(false)  // Continue button activated
 					setSpinner(false); // stop display of spinner
 				} else {
-					console.log("check html file after 5s");
+					console.log("check highlights file after 5s");
 					setTimeout(html_file_loop, 5000);
 				}
 			};

--- a/src/components/childComponents/CreateAndUpload.js
+++ b/src/components/childComponents/CreateAndUpload.js
@@ -61,7 +61,7 @@ export default function CreateAndUpload() {
 					const metadata = await getDatasetMetadata(dataset_id, clientInfo);
 					console.log("metadata", metadata);
 					// get the metadata content list
-					const contentList = metadata.map(item => item.content[0]);
+					const contentList = metadata.map(item => item.content);
 					const pdfExtractorContent = contentList.find(item => item.extractor === pdfExtractor);
 					const rctExtractorContent = contentList.find(item => item.extractor === rctExtractor);
 					if (pdfExtractorContent){

--- a/src/components/childComponents/FilePreview.js
+++ b/src/components/childComponents/FilePreview.js
@@ -59,7 +59,7 @@ export default function FilePreview() {
 	// useEffect on datasetMetadata to load preview leftdrawer metadata
 	useEffect( async ()=> {
 		if (datasetMetadata !== undefined) {
-			const contentList = datasetMetadata.map(item => item.content[0]);
+			const contentList = datasetMetadata.map(item => item.content);
 			const pdfExtractorContent = contentList.find(item => item.extractor === pdfExtractor);
 			const rctExtractorContent = contentList.find(item => item.extractor === rctExtractor);
 			if (pdfExtractorContent){

--- a/src/components/childComponents/PreviewDrawerLeft.js
+++ b/src/components/childComponents/PreviewDrawerLeft.js
@@ -120,11 +120,11 @@ export default function PreviewDrawerLeft(props) {
 											<List disablePadding>
 												{
 													check_item.items.length > 0 ?
-														check_item.items.map((item, index) => {
-															const found = item.found === "Yes";
+														check_item.items.map((i, index) => {
+															const found = i.found === "Yes";
 															return (
 																<ListItemButton key={index} sx={{ pl: 4 }}>
-																	<ListItemText primary={item.item} secondary={item.topic}/>
+																	<ListItemText primary={i.item} secondary={i.topic}/>
 																	{found ? <CheckIcon style={{color:"green"}} /> : <CancelIcon style={{color:"red"}} />}
 																</ListItemButton>
 															);

--- a/src/components/previewers/Pdf.js
+++ b/src/components/previewers/Pdf.js
@@ -170,27 +170,19 @@ export default function Pdf(props) {
 				let [text_p, text_x, text_y, text_width, text_height] = coordsList[0].split(',').map(Number);
 				text_x = text_x * scale_x;
 				text_y = text_y * scale_y;
+				text_width = text_width * scale_x;
 				// put labels to either side of text
-				if (text_x < 100){
-					text_x = 10;
+				if (text_x < (canvas_width * scale_x)/2){
+					text_x = 10 * scale_x;
 				}
 				else{
-					text_x = text_x + text_width + 2;
+					text_x = text_x + text_width + (2 * scale_x);
 				}
-				let text_label = label;
-				context.globalAlpha = 1.0
-				context.font = "10px Verdana";
-				context.fillStyle = 'red';
-				context.fillText(text_label, text_x, text_y);
-
+				highlightLabel(context, label, text_x, text_y)
 				// Draw rectangles based on coordinates
 				for (let i = 0; i < coordsList.length; i++) {
-					let [p, x, y, width, height] = coordsList[i].split(',').map(Number);
-					// rectangle highlights styling
-					context.globalAlpha = 0.2
-					context.fillStyle = 'rgb(255, 190, 60)';
-					context.fillRect(x * scale_x, y * scale_y, width * scale_x, height * scale_y);
-
+					const [p, x, y, width, height] = coordsList[i].split(',').map(Number);
+					highlightText(context, label, x * scale_x, y * scale_y, width * scale_x, height * scale_y);
 				}
 			});
 
@@ -204,13 +196,14 @@ export default function Pdf(props) {
 			<div>
 				<Document file={pdfSrc} onLoadSuccess={onDocumentLoadSuccess}>
 					<Page className={"PDFPage"}
-						key={`page_${pageNumber + 1}`}
-						pageNumber={pageNumber}
-						canvasRef={canvas}
-						onRenderSuccess={renderHighlights}
-						renderTextLayer={true}
-						renderAnnotationLayer={false}
-						width={pageWidth}
+						  key={`page_${pageNumber + 1}`}
+						  pageNumber={pageNumber}
+						  onLoadSuccess={onPageLoadSuccess}
+						  canvasRef={canvas}
+						  onRenderSuccess={renderHighlights}
+						  renderTextLayer={true}
+						  renderAnnotationLayer={false}
+						  width={pageWidth}
 					/>
 				</Document>
 			</div>

--- a/src/components/previewers/Pdf.js
+++ b/src/components/previewers/Pdf.js
@@ -5,6 +5,46 @@ import "react-pdf/dist/esm/Page/TextLayer.css";
 
 pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.js`;
 
+const highlight_color = {
+	"1a":"#88FF88",
+	"1b":"#88FF88",
+	"2a": "#CCAAFF",
+	"2b": "#CCAAFF",
+	"3a": "#88FFFF",
+	"3b": "#88FFFF",
+	"4a": "#88FFFF",
+	"4b": "#88FFFF",
+	"5":  "#88FFFF",
+	"6a": "#88FFFF",
+	"6b": "#88FFFF",
+	"7a": "#88FFFF",
+	"7b": "#88FFFF",
+	"8a": "#88FFFF",
+	"8b": "#88FFFF",
+	"9" : "#88FFFF",
+	"10" :"#88FFFF",
+	"11a" :"#88FFFF",
+	"11b" :"#88FFFF",
+	"12a ":"#88FFFF",
+	"12b" :"#88FFFF",
+	"13a":"#bbff44",
+	"13b" :"#bbff44",
+	"14a" :"#bbff44",
+	"14b" :"#bbff44",
+	"15" :"#bbff44",
+	"16" :"#bbff44",
+	"17a" :"#bbff44",
+	"17b" :"#bbff44",
+	"18" :"#bbff44",
+	"19" :"#bbff44",
+	"20" :"#AACCFF",
+	"21" :"#AACCFF",
+	"22" :"#AACCFF",
+	"23" :"#FFAACC",
+	"24" :"#FFAACC",
+	"25" :"#FFAACC",
+}
+
 
 export default function Pdf(props) {
 	const {fileId, pdfSrc, metadata, ...other} = props;
@@ -18,6 +58,10 @@ export default function Pdf(props) {
 	const [pageNumber, setPageNumber] = useState(1);
 	const [pageWidth, setPageWidth] = useState(500);
 	const [pageHeight, setPageHeight]= useState(799);
+	const [canvas_width, setCanvasWidth] = useState(500);
+	const [canvas_height, setCanvasHeight] = useState(800);
+	const [scale_x, setScaleX] = useState(1);
+	const [scale_y, setScaleY] = useState(1);
 
 
 	useEffect(() => {
@@ -41,12 +85,19 @@ export default function Pdf(props) {
 			console.log("Error metadata undefined");
 		}
 
-	}, []);
+	}, [metadata]);
 
 
 	function onDocumentLoadSuccess({ numPages }) {
 		setNumPages(numPages);
 		setPageNumber(1);
+	}
+
+	function onPageLoadSuccess(){
+		setCanvasWidth(canvas.current.width);
+		setCanvasHeight(canvas.current.height);
+		setScaleY(canvas_height / pageHeight);
+		setScaleX(canvas_width / pageWidth);
 	}
 
 	function changePage(offset) {
@@ -77,6 +128,24 @@ export default function Pdf(props) {
 		console.log("pageHighlights:", pageHighlights);
 
 		return pageHighlights;
+	}
+
+	function highlightText(context, label, x, y, width, height){
+		// rectangle highlights styling
+		context.globalAlpha = 0.2
+		context.fillStyle = highlight_color[label];  // 'rgb(255, 190, 60)';
+		context.fillRect(x , y , width , height );
+	}
+
+	function highlightLabel(context, label, x, y){
+		context.globalAlpha = 1.0
+		context.font = "10px Verdana";
+		context.fillStyle =  highlight_color[label];
+		context.fillRect(x, y, 20, 10);
+		context.fillStyle = 'red';
+		context.textAlign = "start";
+		context.textBaseline = "top";
+		context.fillText(label, x, y);
 	}
 
 

--- a/src/components/previewers/Pdf.js
+++ b/src/components/previewers/Pdf.js
@@ -45,6 +45,46 @@ const highlight_color = {
 	"25" :"#FFAACC",
 }
 
+const label_color = {
+	"1a":"#009c00",
+	"1b":"#009c00",
+	"2a": "#4400aa",
+	"2b": "#4400aa",
+	"3a": "#009c9c",
+	"3b": "#009c9c",
+	"4a": "#009c9c",
+	"4b": "#009c9c",
+	"5":  "#009c9c",
+	"6a": "#009c9c",
+	"6b": "#009c9c",
+	"7a": "#009c9c",
+	"7b": "#009c9c",
+	"8a": "#009c9c",
+	"8b": "#009c9c",
+	"9" : "#009c9c",
+	"10" :"#009c9c",
+	"11a" :"#009c9c",
+	"11b" :"#009c9c",
+	"12a ":"#009c9c",
+	"12b" :"#009c9c",
+	"13a":"#528100",
+	"13b" :"#528100",
+	"14a" :"#528100",
+	"14b" :"#528100",
+	"15" :"#528100",
+	"16" :"#528100",
+	"17a" :"#528100",
+	"17b" :"#528100",
+	"18" :"#528100",
+	"19" :"#528100",
+	"20" :"#0044aa",
+	"21" :"#0044aa",
+	"22" :"#0044aa",
+	"23" :"#0044aa",
+	"24" :"#0044aa",
+	"25" :"#0044aa",
+}
+
 
 export default function Pdf(props) {
 	const {fileId, pdfSrc, metadata, ...other} = props;
@@ -139,10 +179,10 @@ export default function Pdf(props) {
 
 	function highlightLabel(context, label, x, y){
 		context.globalAlpha = 1.0
-		context.font = "10px Verdana";
 		context.fillStyle =  highlight_color[label];
-		context.fillRect(x, y, 20, 10);
-		context.fillStyle = 'red';
+		context.fillRect(x, y, 25, 12);
+		context.font = "bold 12px Verdana";
+		context.fillStyle = label_color[label];
 		context.textAlign = "start";
 		context.textBaseline = "top";
 		context.fillText(label, x, y);


### PR DESCRIPTION
highlight sentence in frontend PdfPreview. Sentences and coordinates read from "highlights.json" output file from rct-extractor.

Label is displayed once per sentence near the first coordinates list. Label displayed on either side of the text. If the text is on the left side, label is displayed on the left margin. If text on right, label is displayed after "text_width".

Known issues : 
1. If sentence has multiple labels, the labels are displayed on top of each other as the label position is the same. 
2. Determining if the text is on the left side or not is a hardcoded decision - If the x coordinate is < half the canvas width, it is left-aligned and if not its right-aligned. This causes some labels to be displayed on top of other texts, if texts are in the margin -- depending on the original pdf style.


**Fixes #70 #75**